### PR TITLE
FBCrypto and BouncyCastle version bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.apollocurrency</groupId>
   <artifactId>apl-bom-ext</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>pom</packaging>
   <name>apl-bom-ext</name>
 
@@ -52,8 +52,8 @@
 
     <!--Crypto-->
 
-    <fbcrypto.version>1.2.11</fbcrypto.version>
-    <bcprov.version>1.64</bcprov.version>
+    <fbcrypto.version>2.0.0</fbcrypto.version>
+    <bcprov.version>1.65</bcprov.version>
 
 
     <!--QR-code-->
@@ -308,13 +308,13 @@
         <artifactId>resteasy-multipart-provider</artifactId>
         <version>${resteasy.version}</version>
       </dependency>
-<!--
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jaxrs</artifactId>
-        <version>3.11.2.Final</version>
-      </dependency>
--->
+      <!--
+            <dependency>
+              <groupId>org.jboss.resteasy</groupId>
+              <artifactId>resteasy-jaxrs</artifactId>
+              <version>3.11.2.Final</version>
+            </dependency>
+      -->
       <dependency> <!-- Needed by FAT JAR in run-time -->
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-tracing-api</artifactId>


### PR DESCRIPTION
Versions: FBCrypto is 2.0.0 and BouncyCaste is 1.65
BOM version: 1.0.1