### PR TITLE
add mariadb flyway support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <ethereumj-core.version>1.7.2-RELEASE</ethereumj-core.version>
     <jboss-logging-main.version>3.4.1.Final</jboss-logging-main.version>
     <jboss-logging-optional.version>2.1.0.Final</jboss-logging-optional.version>
-    <jta.version>1.1</jta.version>
+    <jta.version>2.0.1</jta.version>
     <two-factor.version>1.0</two-factor.version>
   </properties>
 
@@ -418,8 +418,8 @@
         <version>${jboss-logging-optional.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.transaction</groupId>
-        <artifactId>jta</artifactId>
+        <groupId>jakarta.transaction</groupId>
+        <artifactId>jakarta.transaction-api</artifactId>
         <version>${jta.version}</version>
       </dependency>
 
@@ -488,6 +488,11 @@
       <dependency>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-core</artifactId>
+        <version>${flyway.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-mysql</artifactId>
         <version>${flyway.version}</version>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <resteasy.version>6.2.2.Final</resteasy.version>
     <resteasy-tracing.version>2.0.0.Final</resteasy-tracing.version>
     <swagger.version>2.2.7</swagger.version>
-    <junit5-bom.version>5.9.1</junit5-bom.version>
+    <junit5-bom.version>5.9.2</junit5-bom.version>
     <mockito.version>4.10.0</mockito.version>
     <hikari.version>3.4.1</hikari.version>
     <jcommander.version>1.72</jcommander.version>


### PR DESCRIPTION
We have many unit tests tagged by 'slow' mark which are run with 'test containers' and MariaDb in docker. That is why we need to add optional library here.
- flyway mysql is added
- switched to another JTA library (jakarta)